### PR TITLE
Update overlay information for Gentoo Linux

### DIFF
--- a/documentation/compilation.md
+++ b/documentation/compilation.md
@@ -51,9 +51,9 @@ You can install the repository by executing the following steps:
 
 ### Gentoo
 
-For Gentoo you can use the [stuge overlay](http://git.stuge.se/?p=stuge-overlay.git;a=summary) via layman:
+For Gentoo you can use the [stuge overlay](https://github.com/das-labor/overlay) via layman:
 
-    $ layman -a stuge-overlay
+    $ layman -a das-labor
     $ emerge -av usbguard
 
 ### Usage


### PR DESCRIPTION
USBGuard can now be found in the das-labor overlay.

Bugs: https://github.com/pentoo/pentoo-overlay/issues/124