### PR TITLE
New release: usbguard-0.7.6 doc update

### DIFF
--- a/_includes/asides/latest_release.html
+++ b/_includes/asides/latest_release.html
@@ -2,7 +2,7 @@
   <h2>Latest Release</h2>
   <ul>
     <li>
-      <a href="https://github.com/dkopecek/usbguard/releases/">usbguard-0.7.5</a>
+      <a href="https://github.com/dkopecek/usbguard/releases/">usbguard-0.7.6</a>
     </li>
   </ul>
 </aside>

--- a/_posts/2019-11-11-usbguard-0.7.6.md
+++ b/_posts/2019-11-11-usbguard-0.7.6.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "New release: usbguard-0.7.6, and project enhancements!"
+author: Radovan Sroka <rsroka@redhat.com>
+date: 2019-11-11 14:00:00+02:00
+tags: [usbguard, release notes]
+comments: false
+---
+
+# New release: usbguard-0.7.6, and important projects updates again!
+
+A new release of USBGuard is available and it brings important bug fixes and new features. See the [release page](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.6 "release page") at Github for more information about the release.
+
+Now the important projects updates I would like to announce:
+1. Unfortunately, I made a mistake in git workflow thus the release has not a verified sign next to release 0.7.6.
+2. The proof-of-concept Qt applet was substituted with a brand new project called [usbguard-notifier](https://github.com/Cropi/usbguard-notifier).
+
+# Change Log
+## Added
+
+- Added missing options in manpage usbguard-daemon(8)
+- Extended the functionality of allow/block/reject commands the command can handle rule as a param and not only its ID e.g. in case of allow, command will allow each device that matches provided rule
+- Added debug info for malformed descriptors
+
+## Fixed/Changed
+
+- Changed default backend to uevent
+- Fixed handling of add uevents during scanning now we are sure that the enumeration is completed before processing any uevent we are trying to avoid a race where the kernel is still enumerating the devices and send the uevent while the parent is being authorised
+- Silenced 'bind' and 'unbind' uevents
+
+## Thanks
+
+Many thanks to the following people for contributions to this release and to the USBGuard project:
+
+- [Allen-Webb](https://github.com/Allen-Webb)
+- [Attila Lakatos](https://github.com/Cropi)
+- [Thiebaud Weksteen](https://github.com/tweksteen)
+- [userWayneCampbell](https://github.com/userWayneCampbell)
+- [Zoltan Fridrich](https://github.com/ZoltanFridrich)
+
+
+Regards, Radovan


### PR DESCRIPTION
* New post about the brand-new release [usbguard-0.7.6](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.6)