### PR TITLE
Create 2020-05-19-usbguard-0.7.7 and 0.7.8 upstream release changelog

### DIFF
--- a/_includes/asides/latest_release.html
+++ b/_includes/asides/latest_release.html
@@ -2,7 +2,7 @@
   <h2>Latest Release</h2>
   <ul>
     <li>
-      <a href="https://github.com/dkopecek/usbguard/releases/">usbguard-0.7.6</a>
+      <a href="https://github.com/dkopecek/usbguard/releases/">usbguard-0.7.8</a>
     </li>
   </ul>
 </aside>

--- a/_posts/2020-05-19-usbguard-0.7.7.md
+++ b/_posts/2020-05-19-usbguard-0.7.7.md
@@ -1,0 +1,62 @@
+---
+layout: post
+title: "New release: usbguard-0.7.7, and project enhancements!"
+author: Radovan Sroka <rsroka@redhat.com>
+date: 2020-05-19 08:00:00+02:00
+tags: [usbguard, release notes]
+comments: false
+---
+
+# New release: usbguard-0.7.7, and important projects updates are here!
+
+A new release of USBGuard is available and it brings important bug fixes and new features. See the [release page](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.7 "release page") at Github for more information about the release.
+
+# Change Log
+## Added
+
+- Added readwritepath to service file
+- Added match-all keyword to rules language
+- Added rules.d feature - daemon can load multiple rule files from rules.d/
+- Included with-connect-type in dbus signal
+- Add configure flags for optional libraries
+- Public API documentation
+
+## Fixed/Changed
+
+- Fixed sigwaitinfo handling
+- Fixed possible data corruption on stack with appendRule via dbus
+- Fixed ENOBUFS errno handling on netlink socket
+- Daemon can survive and wait until socket is readable again
+- Make: explicitly treat pthread as first level dependency
+- Added missing options to manual pages
+
+## Removed
+
+- Dropped unused PIDFile from service file
+- Dropped deprecated dbus-glib dependency
+
+## Rules.d feature in more detail
+
+- Users of usbguard can set rules.d folder path in the same way they specify RuleFile.
+- The USBGuard daemon will use this folder to load the policy rule set from it and to write new rules received via the IPC interface.
+- Usually, we set the option to /etc/usbguard/rules.d/.
+- The USBGuard daemon is supposed to behave like any other standard Linux daemon therefore it loads rule files in alpha-numeric order.
+- File names inside RuleFolder directory should start with a two-digit number prefix indicating the position, in which the rules are scanned by the daemon.
+- Setting up RuleFolder is as easy as the following: RuleFolder=/path/to/rulesfolder/
+
+## Thanks
+
+Many thanks to the following people for contributions to this release and to the USBGuard project:
+
+- [Allen-Webb](https://github.com/Allen-Webb)
+- [Attila Lakatos](https://github.com/Cropi)
+- [Thiebaud Weksteen](https://github.com/tweksteen)
+- [userWayneCampbell](https://github.com/userWayneCampbell)
+- [Zoltan Fridrich](https://github.com/ZoltanFridrich)
+- [Birger Schacht](https://github.com/bisco2)
+- [Marek Tamaskovic](https://github.com/tammar96)
+- [muelli](https://github.com/muelli)
+- [Sebastian Pipping](https://github.com/hartwork)
+- [Levente Polyak](https://github.com/anthraxx)
+
+Regards, Radovan

--- a/_posts/2020-05-20-usbguard-0.7.8.md
+++ b/_posts/2020-05-20-usbguard-0.7.8.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: "New release: usbguard-0.7.8, and project enhancements!"
+author: Radovan Sroka <rsroka@redhat.com>
+date: 2020-05-20 08:00:00+02:00
+tags: [usbguard, release notes]
+comments: false
+---
+
+# New release: usbguard-0.7.8, and important projects updates are here!
+
+A new release of USBGuard is available and it brings important bug fixes. See the [release page](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.8 "release page") at Github for more information about the release. This release mainly contains bugfixes related to the rules.d feature introduced in 0.7.7.
+
+# Change Log
+## Fixed/Changed
+
+- Reworked upsertRule logic
+- Extended rules.d folder description with naming conventions
+- Multiple segfault fixes regarding rules.d feature
+
+## Thanks
+
+Many thanks to the following people for contributions to this release and to the USBGuard project:
+
+- [Allen-Webb](https://github.com/Allen-Webb)
+- [Attila Lakatos](https://github.com/Cropi)
+- [Thiebaud Weksteen](https://github.com/tweksteen)
+- [userWayneCampbell](https://github.com/userWayneCampbell)
+- [Zoltan Fridrich](https://github.com/ZoltanFridrich)
+- [Birger Schacht](https://github.com/bisco2)
+- [Marek Tamaskovic](https://github.com/tammar96)
+- [muelli](https://github.com/muelli)
+- [Sebastian Pipping](https://github.com/hartwork)
+- [Levente Polyak](https://github.com/anthraxx)
+
+Regards, Radovan


### PR DESCRIPTION
Update [usbguard wiki page](https://usbguard.github.io/) with the following release informations:

- [usbguard 0.7.7](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.7)
- [usbguard 0.7.8](https://github.com/USBGuard/usbguard/releases/tag/usbguard-0.7.8)